### PR TITLE
fix: handle entrypoint-configured IPs when main.py re-checks

### DIFF
--- a/src/bacnet_sim/networking.py
+++ b/src/bacnet_sim/networking.py
@@ -86,6 +86,11 @@ def compute_virtual_ips(
 
 def _ip_exists(ip: str, interface: str = "eth0") -> bool:
     """Check if an IP address is already assigned to the interface."""
+    _validate_interface(interface)
+
+    if platform.system() != "Linux":
+        return False
+
     try:
         result = subprocess.run(
             ["ip", "-4", "-o", "addr", "show", interface],

--- a/src/bacnet_sim/networking.py
+++ b/src/bacnet_sim/networking.py
@@ -84,6 +84,20 @@ def compute_virtual_ips(
     return virtual_ips
 
 
+def _ip_exists(ip: str, interface: str = "eth0") -> bool:
+    """Check if an IP address is already assigned to the interface."""
+    try:
+        result = subprocess.run(
+            ["ip", "-4", "-o", "addr", "show", interface],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return f" {ip}/" in result.stdout
+    except subprocess.CalledProcessError:
+        return False
+
+
 def add_virtual_ip(ip: str, prefix_length: int, interface: str = "eth0") -> bool:
     """Add a virtual IP address to the network interface.
 
@@ -108,6 +122,12 @@ def add_virtual_ip(ip: str, prefix_length: int, interface: str = "eth0") -> bool
     except subprocess.CalledProcessError as e:
         if "RTNETLINK answers: File exists" in e.stderr:
             logger.warning("Virtual IP %s already exists on %s", ip, interface)
+            return True
+        # The entrypoint may have already added IPs as root before dropping
+        # privileges.  If we lack permission, check whether the IP is already
+        # present on the interface and treat that as success.
+        if "Operation not permitted" in e.stderr and _ip_exists(ip, interface):
+            logger.info("Virtual IP %s already present on %s (set up by entrypoint)", ip, interface)
             return True
         logger.error("Failed to add virtual IP %s: %s", ip, e.stderr.strip())
         return False

--- a/tests/test_networking.py
+++ b/tests/test_networking.py
@@ -1,10 +1,11 @@
 """Tests for virtual IP networking module."""
 
+import subprocess
 from unittest.mock import patch
 
 import pytest
 
-from bacnet_sim.networking import compute_virtual_ips, setup_virtual_ips
+from bacnet_sim.networking import _ip_exists, add_virtual_ip, compute_virtual_ips, setup_virtual_ips
 
 
 class TestComputeVirtualIps:
@@ -91,3 +92,62 @@ class TestSetupVirtualIps:
                 prefix_length=24,
                 device_count=2,
             )
+
+
+class TestIpExists:
+    @patch("bacnet_sim.networking.platform.system", return_value="Linux")
+    @patch("bacnet_sim.networking.subprocess.run")
+    def test_ip_found(self, mock_run, mock_system):
+        mock_run.return_value.stdout = (
+            "2: eth0    inet 172.18.0.10/24 brd 172.18.0.255 scope global eth0\n"
+            "2: eth0    inet 172.18.0.11/24 brd 172.18.0.255 scope global secondary eth0\n"
+        )
+        assert _ip_exists("172.18.0.11", "eth0") is True
+
+    @patch("bacnet_sim.networking.platform.system", return_value="Linux")
+    @patch("bacnet_sim.networking.subprocess.run")
+    def test_ip_not_found(self, mock_run, mock_system):
+        mock_run.return_value.stdout = (
+            "2: eth0    inet 172.18.0.10/24 brd 172.18.0.255 scope global eth0\n"
+        )
+        assert _ip_exists("172.18.0.11", "eth0") is False
+
+    @patch("bacnet_sim.networking.platform.system", return_value="Windows")
+    def test_non_linux_returns_false(self, mock_system):
+        assert _ip_exists("172.18.0.11", "eth0") is False
+
+    @patch("bacnet_sim.networking.platform.system", return_value="Linux")
+    @patch(
+        "bacnet_sim.networking.subprocess.run",
+        side_effect=subprocess.CalledProcessError(1, "ip"),
+    )
+    def test_command_failure_returns_false(self, mock_run, mock_system):
+        assert _ip_exists("172.18.0.11", "eth0") is False
+
+
+class TestAddVirtualIpEntrypointFallback:
+    """Test add_virtual_ip handles IPs already set up by the entrypoint."""
+
+    @patch("bacnet_sim.networking._ip_exists", return_value=True)
+    @patch("bacnet_sim.networking.platform.system", return_value="Linux")
+    @patch("bacnet_sim.networking.subprocess.run")
+    def test_permitted_err_ip_exists_returns_true(
+        self, mock_run, mock_system, mock_exists,
+    ):
+        """'Operation not permitted' + IP exists → True."""
+        mock_run.side_effect = subprocess.CalledProcessError(
+            2, "ip", stderr="RTNETLINK answers: Operation not permitted\n"
+        )
+        assert add_virtual_ip("172.18.0.11", 24) is True
+
+    @patch("bacnet_sim.networking._ip_exists", return_value=False)
+    @patch("bacnet_sim.networking.platform.system", return_value="Linux")
+    @patch("bacnet_sim.networking.subprocess.run")
+    def test_permitted_err_ip_missing_returns_false(
+        self, mock_run, mock_system, mock_exists,
+    ):
+        """'Operation not permitted' + IP missing → False."""
+        mock_run.side_effect = subprocess.CalledProcessError(
+            2, "ip", stderr="RTNETLINK answers: Operation not permitted\n"
+        )
+        assert add_virtual_ip("172.18.0.11", 24) is False


### PR DESCRIPTION
## Summary
- The Docker entrypoint (`setup_ips.py`) adds virtual IPs as root, then drops privileges to `appuser` via `gosu`
- When `main.py` starts and calls `setup_virtual_ips()` again, `ip addr add` fails with "Operation not permitted" because `appuser` lacks `NET_ADMIN` capability
- The existing "File exists" handler doesn't catch this because the error message differs
- Adds `_ip_exists()` helper that checks whether an IP is already assigned to the interface
- On "Operation not permitted", checks if the IP already exists and treats it as success

Discovered while testing 9-device multi-device config in bacnet-sim-ci-test.

## Test plan
- [x] Unit tests pass locally (143/143)
- [x] `ruff check` passes
- [x] bacnet-sim-ci-test `test-bacnet-protocol` workflow passes with 9 devices (19/19 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)