### PR TITLE
docs: REST-only vs BACnet protocol networking + pinning/multi-arch notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ services:
   bacnet-sim:
     image: ghcr.io/rise-building-technology/bacnet-sim-ci:latest
     ports:
-      - 47808:47808/udp
-      - 8099:8099
+      - 8099:8099  # REST only; see below for BACnet/IP UDP
     options: >-
       --cap-add=NET_ADMIN
       --health-cmd "curl -f http://localhost:8099/health/ready || exit 1"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ BACnet device simulator for CI pipelines. Runs as a Docker container or GitHub A
 
 ## Quick Start
 
-### GitHub Actions (Service Container)
+### GitHub Actions (Service Container — REST-only)
+
+For tests that only use the HTTP REST API:
 
 ```yaml
 services:
@@ -24,6 +26,8 @@ services:
       --health-retries 10
       --health-start-period 15s
 ```
+
+**If your test client speaks BACnet/IP UDP directly, do not use the `services:` pattern** — docker-proxy drops UDP packets across the bridge. See [Networking → Choosing a pattern](#choosing-a-pattern) and [`examples/workflow-bacnet-protocol.yml`](examples/workflow-bacnet-protocol.yml).
 
 ### GitHub Action
 
@@ -279,7 +283,40 @@ networks:
 
 ### GitHub Actions
 
-When using service containers, the simulator is accessible via `localhost` on the mapped ports. For BACnet protocol access, use the virtual IPs returned by `GET /api/devices`.
+#### Choosing a pattern
+
+| Your test client uses... | Use this pattern | Example |
+|---|---|---|
+| HTTP REST API only | `services:` container | [`workflow-service-container.yml`](examples/workflow-service-container.yml) |
+| BACnet/IP UDP directly | Sibling-container on a custom network | [`workflow-bacnet-protocol.yml`](examples/workflow-bacnet-protocol.yml) |
+
+The `services:` keyword routes container ports through docker-proxy. TCP (REST) works fine, but **UDP packets are unreliable across the bridge** — BACnet `readProperty` / Who-Is calls time out even when the REST healthcheck passes. If your tests use BACnet protocol calls, run your test client as a sibling container on a custom Docker network with fixed IPs so UDP becomes a direct peer-to-peer flow with no NAT.
+
+If REST works but your BACnet client gets timeouts, the test client is almost certainly on the runner host instead of inside a sibling container.
+
+#### Healthcheck context
+
+The `--health-cmd` from the `services:` example runs **inside the simulator's own container**, where `localhost:8099` is the sim's REST API. From the runner host you reach the API via the `ports:` mapping (`localhost:8099`); from a sibling container you reach it directly by service hostname (`bacnet-sim:8099`).
+
+#### Pinning the image for deterministic CI
+
+`:latest` follows new builds and can change without warning. For reproducible CI, pin by digest:
+
+```yaml
+image: ghcr.io/rise-building-technology/bacnet-sim-ci@sha256:29ed481aa6015dc3508a5aec5b2cb5a69c86bdc2ef22bb7ecb0d75c0d7745963
+```
+
+Get the current digest with:
+
+```bash
+docker buildx imagetools inspect ghcr.io/rise-building-technology/bacnet-sim-ci:latest
+```
+
+Bump the digest in your workflow after testing the new build locally.
+
+#### Image platforms
+
+Published as a multi-arch manifest covering `linux/amd64` and `linux/arm64`. Verify with `docker manifest inspect ghcr.io/rise-building-technology/bacnet-sim-ci:latest`.
 
 ## Resource Usage
 
@@ -298,7 +335,7 @@ Each BAC0 device instance uses roughly 30-50 MB. The base process (Python + Fast
 - **BACnet/IP only** (no MSTP, no BACnet/SC)
 - **No COV subscriptions** (Change of Value notifications)
 - **No BBMD** (Broadcast Management Device)
-- **Test client must be on the same Docker network** for BACnet broadcast discovery
+- **Test client must be on the same Docker network** for BACnet broadcast discovery (and a sibling container, not the runner host — see [Networking → Choosing a pattern](#choosing-a-pattern))
 
 ## Development
 

--- a/examples/workflow-bacnet-protocol.yml
+++ b/examples/workflow-bacnet-protocol.yml
@@ -1,0 +1,64 @@
+# Example: Protocol-level BACnet testing via the sibling-container pattern
+#
+# Use this when your test client speaks BACnet/IP UDP (not just the REST API).
+# The standard `services:` keyword routes UDP through docker-proxy, which drops
+# BACnet packets in practice — REST works, but readProperty/Who-Is time out.
+#
+# Pattern: create a custom Docker network with fixed IPs, then run BOTH the
+# simulator and your test client as sibling containers on it. UDP becomes a
+# direct peer-to-peer flow on the same /24 with no NAT.
+#
+# Verified in production at bitpool/edge-bacnet#44 (Node-RED + edge-bacnet
+# discovers the sim in ~7s).
+
+name: BACnet Protocol Tests
+
+on: [push, pull_request]
+
+jobs:
+  bacnet-protocol-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create test network
+        run: docker network create --subnet=172.20.0.0/24 bacnet-test-net
+
+      - name: Start BACnet simulator on the test network
+        run: |
+          docker run -d \
+            --name bacnet-sim \
+            --network bacnet-test-net \
+            --ip 172.20.0.10 \
+            --cap-add=NET_ADMIN \
+            -e BACNET_DEVICE_ID=1001 \
+            -e BACNET_DEVICE_NAME=TestDevice \
+            ghcr.io/rise-building-technology/bacnet-sim-ci:latest
+
+      - name: Wait for simulator readiness
+        run: |
+          for i in $(seq 1 30); do
+            if docker exec bacnet-sim curl -sf http://localhost:8099/health/ready > /dev/null; then
+              echo "Simulator ready"
+              break
+            fi
+            sleep 1
+          done
+
+      - name: Build your test client image
+        run: docker build -t bacnet-test-client .
+
+      - name: Run BACnet test client as a sibling container
+        run: |
+          docker run --rm \
+            --name client \
+            --network bacnet-test-net \
+            --ip 172.20.0.20 \
+            -e BACNET_TARGET_IP=172.20.0.10 \
+            -e BACNET_TARGET_PORT=47808 \
+            bacnet-test-client
+
+      - name: Dump simulator logs on failure
+        if: failure()
+        run: docker logs bacnet-sim

--- a/examples/workflow-bacnet-protocol.yml
+++ b/examples/workflow-bacnet-protocol.yml
@@ -41,10 +41,13 @@ jobs:
           for i in $(seq 1 30); do
             if docker exec bacnet-sim curl -sf http://localhost:8099/health/ready > /dev/null; then
               echo "Simulator ready"
-              break
+              exit 0
             fi
             sleep 1
           done
+          echo "Simulator did not become ready within 30 seconds"
+          docker logs bacnet-sim
+          exit 1
 
       - name: Build your test client image
         run: docker build -t bacnet-test-client .

--- a/examples/workflow-service-container.yml
+++ b/examples/workflow-service-container.yml
@@ -1,7 +1,13 @@
-# Example: Using bacnet-sim-ci as a GitHub Actions service container
+# Example: REST-only integration testing via a GitHub Actions service container
 #
-# This is the recommended approach for long-running integration tests.
-# The simulator runs as a sidecar alongside your test job.
+# Use this when your tests only need the HTTP REST API (read/write objects,
+# snapshot, simulate). REST is reliably reachable from the runner host on
+# `localhost:8099` because docker-proxy handles TCP cleanly.
+#
+# DO NOT use this pattern if your test client speaks BACnet/IP UDP directly —
+# docker-proxy drops UDP packets across the bridge and BACnet readProperty /
+# Who-Is will time out even though the REST healthcheck passes. For protocol-
+# level testing see `workflow-bacnet-protocol.yml` (sibling-container pattern).
 
 name: BACnet Integration Tests
 

--- a/examples/workflow-service-container.yml
+++ b/examples/workflow-service-container.yml
@@ -21,8 +21,7 @@ jobs:
       bacnet-sim:
         image: ghcr.io/rise-building-technology/bacnet-sim-ci:latest
         ports:
-          - 47808:47808/udp
-          - 8099:8099
+          - 8099:8099  # REST only — no UDP mapping; see workflow-bacnet-protocol.yml for protocol-level testing
         env:
           BACNET_DEVICE_ID: "1001"
           BACNET_DEVICE_NAME: "TestDevice"


### PR DESCRIPTION
## Summary

Bundles two consumer-feedback docs issues from wiring CI on [bitpool/edge-bacnet#44](https://github.com/bitpool/edge-bacnet/pull/44).

- **#41** — adds [`examples/workflow-bacnet-protocol.yml`](examples/workflow-bacnet-protocol.yml) (sibling-container pattern), updates the existing [`workflow-service-container.yml`](examples/workflow-service-container.yml) header to flag itself as REST-only with a pointer to the new file, and adds a "Choosing a pattern" table + UDP-bridge explanation to the README Networking section.
- **#43** — three small README additions: digest-pinning example with the current index digest, a "healthcheck runs inside the container" clarification, and a multi-arch verification note (verified `linux/amd64` + `linux/arm64` are both published via `docker manifest inspect`).

## Why now

Each of these is a friction point a real consumer hit. Documenting them costs little and prevents the next consumer from running into the same iterations.

## Test plan

- [ ] Render the README on GitHub and verify the new anchor link `[Networking → Choosing a pattern](#choosing-a-pattern)` resolves.
- [ ] Sanity-check the new `workflow-bacnet-protocol.yml` for shell quoting and YAML validity.
- [ ] Confirm the digest in the pinning example still resolves (`docker manifest inspect ghcr.io/...@sha256:29ed481aa6...`).

Closes #41
Closes #43