### PR TITLE
fix!: align REST write payload to presentValue (closes #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,15 @@ curl http://localhost:8099/api/devices
 ### Read/Write Objects
 
 ```bash
-# Read
-curl http://localhost:8099/api/devices/1001/objects/analog-input/1
+# Read (any object)
+curl http://localhost:8099/api/devices/1001/objects/analog-output/1
 
-# Write
-curl -X PUT http://localhost:8099/api/devices/1001/objects/analog-input/1 \
+# Write (commandable objects only — analog-output, binary-output, or
+# anything with `commandable: true`. Pass ?force=true to write to a
+# non-commandable object such as analog-input.)
+curl -X PUT http://localhost:8099/api/devices/1001/objects/analog-output/1 \
   -H "Content-Type: application/json" \
-  -d '{"presentValue": 75.0}'
+  -d '{"presentValue": 72.0}'
 ```
 
 ### Change Network Profile at Runtime

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ curl http://localhost:8099/api/devices/1001/objects/analog-input/1
 # Write
 curl -X PUT http://localhost:8099/api/devices/1001/objects/analog-input/1 \
   -H "Content-Type: application/json" \
-  -d '{"value": 75.0}'
+  -d '{"presentValue": 75.0}'
 ```
 
 ### Change Network Profile at Runtime

--- a/examples/workflow-multi-device.yml
+++ b/examples/workflow-multi-device.yml
@@ -35,7 +35,7 @@ jobs:
           # Set zone temperature on device 1001
           curl -s -X PUT http://localhost:8099/api/devices/1001/objects/analog-input/1 \
             -H "Content-Type: application/json" \
-            -d '{"value": 75.0}' | python -m json.tool
+            -d '{"presentValue": 75.0}' | python -m json.tool
 
       - name: Run your BACnet integration tests
         run: |

--- a/examples/workflow-multi-device.yml
+++ b/examples/workflow-multi-device.yml
@@ -32,10 +32,10 @@ jobs:
 
       - name: Mutate values via HTTP API
         run: |
-          # Set zone temperature on device 1001
-          curl -s -X PUT http://localhost:8099/api/devices/1001/objects/analog-input/1 \
+          # Set Zone Setpoint on device 1001 (analog-output/1 is commandable)
+          curl -s -X PUT http://localhost:8099/api/devices/1001/objects/analog-output/1 \
             -H "Content-Type: application/json" \
-            -d '{"presentValue": 75.0}' | python -m json.tool
+            -d '{"presentValue": 72.0}' | python -m json.tool
 
       - name: Run your BACnet integration tests
         run: |

--- a/src/bacnet_sim/api.py
+++ b/src/bacnet_sim/api.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 class WriteValueRequest(BaseModel):
-    value: float | int | str | bool
+    presentValue: float | int | str | bool
 
 
 class BulkReadItem(BaseModel):
@@ -37,7 +37,7 @@ class BulkReadRequest(BaseModel):
 class BulkWriteItem(BaseModel):
     type: str
     instance: int
-    value: float | int | str | bool
+    presentValue: float | int | str | bool
 
 
 class BulkWriteRequest(BaseModel):
@@ -322,7 +322,7 @@ def create_app(devices: list[SimulatedDevice]) -> FastAPI:
         try:
             bacnet_obj = device.get_object(obj_config.name)
             sim_manager.stop(device.device_id, obj_config.name)
-            bacnet_obj.presentValue = body.value
+            bacnet_obj.presentValue = body.presentValue
             return {
                 "type": obj_config.type.value,
                 "instance": obj_config.instance,
@@ -438,7 +438,7 @@ def create_app(devices: list[SimulatedDevice]) -> FastAPI:
             try:
                 bacnet_obj = device.get_object(obj_config.name)
                 sim_manager.stop(device.device_id, obj_config.name)
-                bacnet_obj.presentValue = item.value
+                bacnet_obj.presentValue = item.presentValue
                 written += 1
             except Exception as e:
                 errors.append({"type": item.type, "instance": item.instance, "error": str(e)})

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -425,7 +425,11 @@ class TestSimulationEndpoints:
 
 class TestStateManagement:
     def test_reset(self, client):
-        client.put("/api/devices/1001/objects/analog-input/1", json={"presentValue": 99.0})
+        resp = client.put(
+            "/api/devices/1001/objects/analog-input/1?force=true",
+            json={"presentValue": 99.0},
+        )
+        assert resp.status_code == 200
         resp = client.post("/api/reset")
         assert resp.status_code == 200
         data = resp.json()
@@ -436,7 +440,11 @@ class TestStateManagement:
         resp = client.post("/api/snapshot")
         assert resp.status_code == 200
         snapshot_id = resp.json()["snapshotId"]
-        client.put("/api/devices/1001/objects/analog-input/1", json={"presentValue": 99.0})
+        write_resp = client.put(
+            "/api/devices/1001/objects/analog-input/1?force=true",
+            json={"presentValue": 99.0},
+        )
+        assert write_resp.status_code == 200
         resp = client.post(f"/api/snapshot/{snapshot_id}/restore")
         assert resp.status_code == 200
         data = resp.json()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -154,14 +154,14 @@ class TestObjectEndpoints:
     def test_write_object(self, client):
         resp = client.put(
             "/api/devices/1001/objects/binary-output/1",
-            json={"value": True},
+            json={"presentValue": True},
         )
         assert resp.status_code == 200
 
     def test_write_non_commandable_returns_400(self, client):
         resp = client.put(
             "/api/devices/1001/objects/analog-input/1",
-            json={"value": 75.0},
+            json={"presentValue": 75.0},
         )
         assert resp.status_code == 400
         assert "not commandable" in resp.json()["detail"]
@@ -169,14 +169,14 @@ class TestObjectEndpoints:
     def test_write_non_commandable_with_force(self, client):
         resp = client.put(
             "/api/devices/1001/objects/analog-input/1?force=true",
-            json={"value": 75.0},
+            json={"presentValue": 75.0},
         )
         assert resp.status_code == 200
 
     def test_write_object_not_found(self, client):
         resp = client.put(
             "/api/devices/1001/objects/analog-input/99",
-            json={"value": 75.0},
+            json={"presentValue": 75.0},
         )
         assert resp.status_code == 404
 
@@ -187,7 +187,7 @@ class TestObjectEndpoints:
     def test_write_invalid_object_type(self, client):
         resp = client.put(
             "/api/devices/1001/objects/invalid-type/1",
-            json={"value": 42},
+            json={"presentValue": 42},
         )
         assert resp.status_code == 422
 
@@ -222,7 +222,7 @@ class TestBulkEndpoints:
         resp = client.post(
             "/api/devices/1001/objects/write",
             json={"objects": [
-                {"type": "binary-output", "instance": 1, "value": True},
+                {"type": "binary-output", "instance": 1, "presentValue": True},
             ]},
         )
         assert resp.status_code == 200
@@ -233,7 +233,7 @@ class TestBulkEndpoints:
         resp = client.post(
             "/api/devices/1001/objects/write",
             json={"objects": [
-                {"type": "analog-input", "instance": 1, "value": 75.0},
+                {"type": "analog-input", "instance": 1, "presentValue": 75.0},
             ]},
         )
         assert resp.status_code == 200
@@ -246,7 +246,7 @@ class TestBulkEndpoints:
         resp = client.post(
             "/api/devices/1001/objects/write?force=true",
             json={"objects": [
-                {"type": "analog-input", "instance": 1, "value": 75.0},
+                {"type": "analog-input", "instance": 1, "presentValue": 75.0},
             ]},
         )
         assert resp.status_code == 200
@@ -257,7 +257,7 @@ class TestBulkEndpoints:
         resp = client.post(
             "/api/devices/9999/objects/write",
             json={"objects": [
-                {"type": "analog-input", "instance": 1, "value": 75.0},
+                {"type": "analog-input", "instance": 1, "presentValue": 75.0},
             ]},
         )
         assert resp.status_code == 404
@@ -347,7 +347,7 @@ class TestLagSimulation:
         client = TestClient(app)
         resp = client.put(
             "/api/devices/1001/objects/analog-input/1",
-            json={"value": 75.0},
+            json={"presentValue": 75.0},
         )
         assert resp.status_code == 503
 
@@ -425,7 +425,7 @@ class TestSimulationEndpoints:
 
 class TestStateManagement:
     def test_reset(self, client):
-        client.put("/api/devices/1001/objects/analog-input/1", json={"value": 99.0})
+        client.put("/api/devices/1001/objects/analog-input/1", json={"presentValue": 99.0})
         resp = client.post("/api/reset")
         assert resp.status_code == 200
         data = resp.json()
@@ -436,7 +436,7 @@ class TestStateManagement:
         resp = client.post("/api/snapshot")
         assert resp.status_code == 200
         snapshot_id = resp.json()["snapshotId"]
-        client.put("/api/devices/1001/objects/analog-input/1", json={"value": 99.0})
+        client.put("/api/devices/1001/objects/analog-input/1", json={"presentValue": 99.0})
         resp = client.post(f"/api/snapshot/{snapshot_id}/restore")
         assert resp.status_code == 200
         data = resp.json()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -184,7 +184,7 @@ class TestContainerAPI:
         # Write a new value to Zone Setpoint (analog-output instance 1)
         write_resp = requests.put(
             f"http://localhost:{API_PORT}/api/devices/{device_id}/objects/analog-output/1",
-            json={"value": 68.0},
+            json={"presentValue": 68.0},
         )
         assert write_resp.status_code == 200
 


### PR DESCRIPTION
## Summary

GET responses on `/api/devices/{id}/objects/{type}/{instance}` already return `{presentValue, commandable, statusFlags}` — matching BACnet vocabulary. But PUT and bulk-write took `{value: ...}`. The asymmetric shape silently masks consumer test bugs (e.g. asserting `expectedRest.value` against the GET response gets `undefined`).

This PR renames the request field on:

- `PUT /api/devices/{id}/objects/{type}/{instance}` → body now `{"presentValue": ...}`
- `POST /api/devices/{id}/objects/write` → each item now `{"type", "instance", "presentValue"}`

## Why hard-break (no back-compat)

The repo is pre-1.0 (no `v1` tag exists yet — see #40). Skipping the deprecation shim now keeps the surface area clean for v1.

## Changes

- `src/bacnet_sim/api.py` — `WriteValueRequest` and `BulkWriteItem` Pydantic models renamed `value` → `presentValue`; both endpoint bodies updated.
- `tests/test_api.py` (12 sites) and `tests/test_integration.py` (1 site) — request payloads updated.
- `README.md` — PUT curl example updated.
- `examples/workflow-multi-device.yml` — PUT curl example updated.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/` — clean
- [x] `pytest tests/ -v --ignore=tests/test_integration.py` — 171 passed
- [ ] CI integration tests pass on PR
- [ ] Manual: round-trip a write with `{"presentValue": ...}` against a running container, confirm GET returns the same key
- [ ] Sanity-check OpenAPI at `/docs` shows `presentValue` in request schemas

Closes #42